### PR TITLE
Add Console Entry point to package for command line usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.rst") as f:
 setup(
     name='xdice',
 
-    version='1.2.1',
+    version='1.2.2',
 
     description='The swiss knife for Dice roll : Command line, API (documented!), advanced dice notation parser, compilable patterns...etc.',
     long_description=long_description,
@@ -50,7 +50,11 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
-
+    entry_points = {
+        'console_scripts': [
+            'roll=roll:main'
+        ]
+    },
     keywords='xdice roll d20 game random parser dices role board',
 
 )

--- a/xdice.py
+++ b/xdice.py
@@ -8,7 +8,7 @@
 import random
 import re
 
-__VERSION__ = "1.2.1"
+__VERSION__ = "1.2.2"
 
 def compile(pattern_string):  # @ReservedAssignment
     """


### PR DESCRIPTION
I added an entry point to the setup file which will allow the pip package to be run as a standard command line application. This removes the need to call either python or the `roll.py` file directly.